### PR TITLE
Change BPM position error calculation to 'sp - pos'

### DIFF
--- a/hdl/modules/fofb_ctrl_pkg.vhd
+++ b/hdl/modules/fofb_ctrl_pkg.vhd
@@ -699,7 +699,7 @@ package fofb_ctrl_pkg is
   -- FOFB Processing
   constant c_xwb_fofb_processing_regs_sdb : t_sdb_device := (
     abi_class     => x"0000",                   -- undocumented device
-    abi_ver_major => x"03",
+    abi_ver_major => x"04",
     abi_ver_minor => x"00",
     wbd_endian    => c_sdb_endian_big,
     wbd_width     => x"4",                      -- 32-bit port granularity (0100)

--- a/hdl/modules/fofb_processing/fofb_processing.vhd
+++ b/hdl/modules/fofb_processing/fofb_processing.vhd
@@ -256,7 +256,7 @@ begin
         -- Add an extra clock cycle to ease timing for the subtraction
         -- operation between the received BPM position data and the orbit
         -- set-point
-        bpm_pos_err <= resize(bpm_pos_tmp - signed(sp_pos_ram_data_i), g_BPM_POS_INT_WIDTH + g_BPM_POS_FRAC_WIDTH + 1);
+        bpm_pos_err <= resize(signed(sp_pos_ram_data_i) - bpm_pos_tmp, g_BPM_POS_INT_WIDTH + g_BPM_POS_FRAC_WIDTH + 1);
         bpm_pos_err_valid <= bpm_pos_valid_tmp;
         bpm_time_frame_end <= bpm_time_frame_end_tmp;
         bpm_pos_err_index <= to_integer(bpm_index_tmp);

--- a/hdl/testbench/fofb_processing/fofb_processing_tb.vhd
+++ b/hdl/testbench/fofb_processing/fofb_processing_tb.vhd
@@ -214,11 +214,11 @@ begin
         -- Compute the BPM position error
         if g_USE_MOVING_AVG then
           -- Take the average with the BPM position from the last time frame
-          bpm_err_x := ((bpm_x + bpm_prev_x(i)) / 2) - sp_ram.get_sp_integer(i);
-          bpm_err_y := ((bpm_y + bpm_prev_y(i)) / 2) - sp_ram.get_sp_integer(i + 256);
+          bpm_err_x := sp_ram.get_sp_integer(i) - ((bpm_x + bpm_prev_x(i)) / 2);
+          bpm_err_y := sp_ram.get_sp_integer(i + 256) - ((bpm_y + bpm_prev_y(i)) / 2);
         else
-          bpm_err_x := bpm_x - sp_ram.get_sp_integer(i);
-          bpm_err_y := bpm_y - sp_ram.get_sp_integer(i + 256);
+          bpm_err_x := sp_ram.get_sp_integer(i) - bpm_x;
+          bpm_err_y := sp_ram.get_sp_integer(i + 256) - bpm_y;
         end if;
 
         -- Store the current BPM position for computing the average in the next
@@ -326,9 +326,9 @@ begin
       -- Compute the BPM position error
       if g_USE_MOVING_AVG then
         -- Take the average with the BPM position from the last time frame
-        bpm_err_x := ((bpm_x + bpm_prev_x(0)) / 2) - sp_ram.get_sp_integer(0);
+        bpm_err_x := sp_ram.get_sp_integer(0) - ((bpm_x + bpm_prev_x(0)) / 2);
       else
-        bpm_err_x := bpm_x - sp_ram.get_sp_integer(0);
+        bpm_err_x := sp_ram.get_sp_integer(0) - bpm_x;
       end if;
 
       -- Detect loop interlock due to orbit distortion
@@ -446,9 +446,9 @@ begin
         -- Compute the BPM position error
         if g_USE_MOVING_AVG then
           -- Take the average with the BPM position from the last time frame
-          bpm_err_x := ((bpm_x + bpm_prev_x(0)) / 2) - sp_ram.get_sp_integer(0);
+          bpm_err_x := sp_ram.get_sp_integer(0) - ((bpm_x + bpm_prev_x(0)) / 2);
         else
-          bpm_err_x := bpm_x - sp_ram.get_sp_integer(0);
+          bpm_err_x := sp_ram.get_sp_integer(0) - bpm_x;
         end if;
 
         -- Store the current BPM position for computing the average in the next

--- a/hdl/testbench/xwb_fofb_processing/xwb_fofb_processing_tb.vhd
+++ b/hdl/testbench/xwb_fofb_processing/xwb_fofb_processing_tb.vhd
@@ -462,8 +462,8 @@ begin
 
         -- ########## computing expected dot product internal state ##########
         -- computing bpm position errors
-        bpm_x_err := bpm_x - sp_ram.get_sp_integer(i);
-        bpm_y_err := bpm_y - sp_ram.get_sp_integer(i + 256);
+        bpm_x_err := sp_ram.get_sp_integer(i) - bpm_x;
+        bpm_y_err := sp_ram.get_sp_integer(i + 256) - bpm_y;
 
         -- computing expected dot product internal state
         for j in 0 to g_CHANNELS-1
@@ -635,8 +635,8 @@ begin
 
       -- ########## computing expected dot product internal state ##########
       -- computing bpm position errors
-      bpm_x_err := bpm_x - sp_ram.get_sp_integer(0);
-      bpm_y_err := bpm_y - sp_ram.get_sp_integer(256);
+      bpm_x_err := sp_ram.get_sp_integer(0) - bpm_x;
+      bpm_y_err := sp_ram.get_sp_integer(256) - bpm_y;
 
       -- checking orbit distortion
       if abs(bpm_x_err) > g_ORB_DISTORT_LIMIT or
@@ -832,7 +832,7 @@ begin
 
         -- ########## computing expected dot product internal state ##########
         -- computing bpm position errors
-        bpm_x_err := bpm_x - sp_ram.get_sp_integer(0);
+        bpm_x_err := sp_ram.get_sp_integer(0) - bpm_x;
 
         -- computing expected dot product internal state
         for j in 0 to g_CHANNELS-1


### PR DESCRIPTION
During tests with the new FOFB IOC we observed that all correctors would saturate immediately upon closing the loop, suggesting a positive feed-back somewhere, and after some debugging we found that it was occurring due way the BPM position error was computed by the fofb_processing core.

Conventionally, the error in a control system is calculated as 'reference - measurement', and we assumed this in the upper software stack. But the fofb_processing core was computing the error as 'measurement - reference' instead, and this behavior was masked by a software bug that effectively multiplied all inverse matrix coefficients by '-1'.

This is a breaking change, so I incremented the xwb_fofb_processing ABI major number version to reflect it.