### PR TITLE
Add averaging to power supply current setpoints distortion

### DIFF
--- a/hdl/modules/fofb_sys_id/cheby/doc/wb_fofb_sys_id_regs.html
+++ b/hdl/modules/fofb_sys_id/cheby/doc/wb_fofb_sys_id_regs.html
@@ -88,202 +88,209 @@
 <td class="td_code">prbs.ctl</td>
 </tr>
 <tr class="tr_even">
+<td class="td_code">0x1004</td>
+<td>REG</td>
+<td><A href="#prbs.sp_distort_mov_avg_max_num_taps_sel_cte">prbs.sp_distort_mov_avg_max_num_taps_sel_cte</a></td>
+<td class="td_code">prbs_sp_distort_mov_avg_max_num_taps_sel_cte</td>
+<td class="td_code">prbs.sp_distort_mov_avg_max_num_taps_sel_cte</td>
+</tr>
+<tr class="tr_odd">
 <td class="td_code">0x1040-0x107f</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort">prbs.sp_distort</a></td>
 <td class="td_code">prbs_sp_distort</td>
 <td class="td_code">prbs.sp_distort</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1040-0x107f</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch">prbs.sp_distort.ch</a></td>
 <td class="td_code">prbs_sp_distort_ch</td>
 <td class="td_code">prbs.sp_distort.ch</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1040-0x1043</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.0">prbs.sp_distort.ch.0</a></td>
 <td class="td_code">prbs_sp_distort_ch_0</td>
 <td class="td_code">prbs.sp_distort.ch.0</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1040</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.0.levels">prbs.sp_distort.ch.0.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_0_levels</td>
 <td class="td_code">prbs.sp_distort.ch.0.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1044-0x1047</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.1">prbs.sp_distort.ch.1</a></td>
 <td class="td_code">prbs_sp_distort_ch_1</td>
 <td class="td_code">prbs.sp_distort.ch.1</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1044</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.1.levels">prbs.sp_distort.ch.1.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_1_levels</td>
 <td class="td_code">prbs.sp_distort.ch.1.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1048-0x104b</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.2">prbs.sp_distort.ch.2</a></td>
 <td class="td_code">prbs_sp_distort_ch_2</td>
 <td class="td_code">prbs.sp_distort.ch.2</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1048</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.2.levels">prbs.sp_distort.ch.2.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_2_levels</td>
 <td class="td_code">prbs.sp_distort.ch.2.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x104c-0x104f</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.3">prbs.sp_distort.ch.3</a></td>
 <td class="td_code">prbs_sp_distort_ch_3</td>
 <td class="td_code">prbs.sp_distort.ch.3</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x104c</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.3.levels">prbs.sp_distort.ch.3.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_3_levels</td>
 <td class="td_code">prbs.sp_distort.ch.3.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1050-0x1053</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.4">prbs.sp_distort.ch.4</a></td>
 <td class="td_code">prbs_sp_distort_ch_4</td>
 <td class="td_code">prbs.sp_distort.ch.4</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1050</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.4.levels">prbs.sp_distort.ch.4.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_4_levels</td>
 <td class="td_code">prbs.sp_distort.ch.4.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1054-0x1057</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.5">prbs.sp_distort.ch.5</a></td>
 <td class="td_code">prbs_sp_distort_ch_5</td>
 <td class="td_code">prbs.sp_distort.ch.5</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1054</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.5.levels">prbs.sp_distort.ch.5.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_5_levels</td>
 <td class="td_code">prbs.sp_distort.ch.5.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1058-0x105b</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.6">prbs.sp_distort.ch.6</a></td>
 <td class="td_code">prbs_sp_distort_ch_6</td>
 <td class="td_code">prbs.sp_distort.ch.6</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1058</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.6.levels">prbs.sp_distort.ch.6.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_6_levels</td>
 <td class="td_code">prbs.sp_distort.ch.6.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x105c-0x105f</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.7">prbs.sp_distort.ch.7</a></td>
 <td class="td_code">prbs_sp_distort_ch_7</td>
 <td class="td_code">prbs.sp_distort.ch.7</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x105c</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.7.levels">prbs.sp_distort.ch.7.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_7_levels</td>
 <td class="td_code">prbs.sp_distort.ch.7.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1060-0x1063</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.8">prbs.sp_distort.ch.8</a></td>
 <td class="td_code">prbs_sp_distort_ch_8</td>
 <td class="td_code">prbs.sp_distort.ch.8</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1060</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.8.levels">prbs.sp_distort.ch.8.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_8_levels</td>
 <td class="td_code">prbs.sp_distort.ch.8.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1064-0x1067</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.9">prbs.sp_distort.ch.9</a></td>
 <td class="td_code">prbs_sp_distort_ch_9</td>
 <td class="td_code">prbs.sp_distort.ch.9</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1064</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.9.levels">prbs.sp_distort.ch.9.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_9_levels</td>
 <td class="td_code">prbs.sp_distort.ch.9.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1068-0x106b</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.10">prbs.sp_distort.ch.10</a></td>
 <td class="td_code">prbs_sp_distort_ch_10</td>
 <td class="td_code">prbs.sp_distort.ch.10</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1068</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.10.levels">prbs.sp_distort.ch.10.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_10_levels</td>
 <td class="td_code">prbs.sp_distort.ch.10.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x106c-0x106f</td>
 <td>BLOCK</td>
 <td><A href="#prbs.sp_distort.ch.11">prbs.sp_distort.ch.11</a></td>
 <td class="td_code">prbs_sp_distort_ch_11</td>
 <td class="td_code">prbs.sp_distort.ch.11</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x106c</td>
 <td>REG</td>
 <td><A href="#prbs.sp_distort.ch.11.levels">prbs.sp_distort.ch.11.levels</a></td>
 <td class="td_code">prbs_sp_distort_ch_11_levels</td>
 <td class="td_code">prbs.sp_distort.ch.11.levels</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code">0x1800-0x1fff</td>
 <td>BLOCK</td>
 <td><A href="#prbs.bpm_pos_distort">prbs.bpm_pos_distort</a></td>
 <td class="td_code">prbs_bpm_pos_distort</td>
 <td class="td_code">prbs.bpm_pos_distort</td>
 </tr>
-<tr class="tr_odd">
+<tr class="tr_even">
 <td class="td_code">0x1800-0x1fff</td>
 <td>MEMORY</td>
 <td><A href="#prbs.bpm_pos_distort.distort_ram">prbs.bpm_pos_distort.distort_ram</a></td>
 <td class="td_code">prbs_bpm_pos_distort_distort_ram</td>
 <td class="td_code">prbs.bpm_pos_distort.distort_ram</td>
 </tr>
-<tr class="tr_even">
+<tr class="tr_odd">
 <td class="td_code"> +0x1800</td>
 <td>REG</td>
 <td><A href="#prbs.bpm_pos_distort.distort_ram.levels">prbs.bpm_pos_distort.distort_ram.levels</a></td>
@@ -481,9 +488,7 @@ PRBS distortion control register<br>
  <td class="td_unused" colspan="1">-</td>
  <td class="td_unused" colspan="1">-</td>
  <td class="td_unused" colspan="1">-</td>
- <td class="td_unused" colspan="1">-</td>
- <td class="td_unused" colspan="1">-</td>
- <td class="td_unused" colspan="1">-</td>
+ <td class="td_field" colspan="3">sp_distort_mov_avg_num_taps_sel[2:0]</td>
  <td class="td_field" colspan="1">sp_distort_en</td>
  <td class="td_field" colspan="1">bpm_pos_distort_en</td>
 </tr>
@@ -561,9 +566,57 @@ NOTE: This is only effectived via external trigger.
 write 0: distortion disabled
 write 1: distortion enabled
 
+<li><b>
+sp_distort_mov_avg_num_taps_sel
+</b>[<i>rw</i>]: Selects the number of taps for averaging the setpoints
+distortion. The number of taps being selected is given by
+'2**sp_distort_mov_avg_num_taps_sel'.
+NOTE: The maximum value for this field is given by
+      sp_distort_mov_avg_max_num_taps_sel_cte.
+
+write 0x00: set number of taps to 1 (no averaging)
+write 0x01: set number of taps to 2
+write 0x02: set number of taps to 8
+...
+write sp_distort_mov_avg_max_num_taps_sel_cte : set number
+ of taps to 2**sp_distort_mov_avg_max_num_taps_sel_cte.
+
+</ul>
+<a name="prbs.sp_distort_mov_avg_max_num_taps_sel_cte"></a>
+<h3><a name="sect_3_4">2.4. prbs.sp_distort_mov_avg_max_num_taps_sel_cte</a></h3>
+<table cellpadding=0 cellspacing=0 border=0>
+<tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_mov_avg_max_num_taps_sel_cte</td></tr>
+<tr><td><b>HW address:</b></td><td class="td_code">0x1004</td></tr>
+<tr><td><b>C prefix:</b></td><td class="td_code">prbs.sp_distort_mov_avg_max_num_taps_sel_cte</td></tr>
+<tr><td><b>C block offset:</b></td><td class="td_code">0x4</td></tr>
+</table>
+<p>
+The maximum allowed value for prbs.ctl<br>sp_distort_mov_avg_num_taps_sel field.<br>
+</p>
+<table cellpadding=0 cellspacing=0 border=0>
+<tr>
+ <td class="td_bit" colspan="1">7</td>
+ <td class="td_bit" colspan="1">6</td>
+ <td class="td_bit" colspan="1">5</td>
+ <td class="td_bit" colspan="1">4</td>
+ <td class="td_bit" colspan="1">3</td>
+ <td class="td_bit" colspan="1">2</td>
+ <td class="td_bit" colspan="1">1</td>
+ <td class="td_bit" colspan="1">0</td>
+</tr>
+<tr>
+ <td class="td_field" colspan="8">sp_distort_mov_avg_max_num_taps_sel_cte[7:0]</td>
+</tr>
+</table>
+<ul>
+<li><b>
+sp_distort_mov_avg_max_num_taps_sel_cte
+</b>[<i>ro</i>]: The maximum allowed value for prbs.ctl
+sp_distort_mov_avg_num_taps_sel field.
+
 </ul>
 <a name="prbs.sp_distort.ch.0.levels"></a>
-<h3><a name="sect_3_4">2.4. prbs.sp_distort.ch.0.levels</a></h3>
+<h3><a name="sect_3_5">2.5. prbs.sp_distort.ch.0.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_0_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1040</td></tr>
@@ -640,7 +693,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.1.levels"></a>
-<h3><a name="sect_3_5">2.5. prbs.sp_distort.ch.1.levels</a></h3>
+<h3><a name="sect_3_6">2.6. prbs.sp_distort.ch.1.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_1_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1044</td></tr>
@@ -717,7 +770,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.2.levels"></a>
-<h3><a name="sect_3_6">2.6. prbs.sp_distort.ch.2.levels</a></h3>
+<h3><a name="sect_3_7">2.7. prbs.sp_distort.ch.2.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_2_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1048</td></tr>
@@ -794,7 +847,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.3.levels"></a>
-<h3><a name="sect_3_7">2.7. prbs.sp_distort.ch.3.levels</a></h3>
+<h3><a name="sect_3_8">2.8. prbs.sp_distort.ch.3.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_3_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x104c</td></tr>
@@ -871,7 +924,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.4.levels"></a>
-<h3><a name="sect_3_8">2.8. prbs.sp_distort.ch.4.levels</a></h3>
+<h3><a name="sect_3_9">2.9. prbs.sp_distort.ch.4.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_4_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1050</td></tr>
@@ -948,7 +1001,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.5.levels"></a>
-<h3><a name="sect_3_9">2.9. prbs.sp_distort.ch.5.levels</a></h3>
+<h3><a name="sect_3_10">2.10. prbs.sp_distort.ch.5.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_5_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1054</td></tr>
@@ -1025,7 +1078,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.6.levels"></a>
-<h3><a name="sect_3_10">2.10. prbs.sp_distort.ch.6.levels</a></h3>
+<h3><a name="sect_3_11">2.11. prbs.sp_distort.ch.6.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_6_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1058</td></tr>
@@ -1102,7 +1155,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.7.levels"></a>
-<h3><a name="sect_3_11">2.11. prbs.sp_distort.ch.7.levels</a></h3>
+<h3><a name="sect_3_12">2.12. prbs.sp_distort.ch.7.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_7_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x105c</td></tr>
@@ -1179,7 +1232,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.8.levels"></a>
-<h3><a name="sect_3_12">2.12. prbs.sp_distort.ch.8.levels</a></h3>
+<h3><a name="sect_3_13">2.13. prbs.sp_distort.ch.8.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_8_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1060</td></tr>
@@ -1256,7 +1309,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.9.levels"></a>
-<h3><a name="sect_3_13">2.13. prbs.sp_distort.ch.9.levels</a></h3>
+<h3><a name="sect_3_14">2.14. prbs.sp_distort.ch.9.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_9_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1064</td></tr>
@@ -1333,7 +1386,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.10.levels"></a>
-<h3><a name="sect_3_14">2.14. prbs.sp_distort.ch.10.levels</a></h3>
+<h3><a name="sect_3_15">2.15. prbs.sp_distort.ch.10.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_10_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1068</td></tr>
@@ -1410,7 +1463,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.sp_distort.ch.11.levels"></a>
-<h3><a name="sect_3_15">2.15. prbs.sp_distort.ch.11.levels</a></h3>
+<h3><a name="sect_3_16">2.16. prbs.sp_distort.ch.11.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_sp_distort_ch_11_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x106c</td></tr>
@@ -1487,7 +1540,7 @@ counts for PRBS value 1.
 
 </ul>
 <a name="prbs.bpm_pos_distort.distort_ram.levels"></a>
-<h3><a name="sect_3_16">2.16. prbs.bpm_pos_distort.distort_ram.levels</a></h3>
+<h3><a name="sect_3_17">2.17. prbs.bpm_pos_distort.distort_ram.levels</a></h3>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr><td><b>HW prefix:</b></td><td class="td_code">prbs_bpm_pos_distort_distort_ram_levels</td></tr>
 <tr><td><b>HW address:</b></td><td class="td_code">0x1800</td></tr>

--- a/hdl/modules/fofb_sys_id/cheby/wb_fofb_sys_id_regs.cheby
+++ b/hdl/modules/fofb_sys_id/cheby/wb_fofb_sys_id_regs.cheby
@@ -97,6 +97,30 @@ memory-map:
 
                       write 0: distortion disabled
                       write 1: distortion enabled
+                - field:
+                    name: sp_distort_mov_avg_num_taps_sel
+                    range: 20-18
+                    description: |
+                      Selects the number of taps for averaging the setpoints
+                      distortion. The number of taps being selected is given by
+                      '2**sp_distort_mov_avg_num_taps_sel'.
+                      NOTE: The maximum value for this field is given by
+                            sp_distort_mov_avg_max_num_taps_sel_cte.
+
+                      write 0x00: set number of taps to 1 (no averaging)
+                      write 0x01: set number of taps to 2
+                      write 0x02: set number of taps to 8
+                      ...
+                      write sp_distort_mov_avg_max_num_taps_sel_cte : set number
+                       of taps to 2**sp_distort_mov_avg_max_num_taps_sel_cte.
+          - reg:
+              name: sp_distort_mov_avg_max_num_taps_sel_cte
+              width: 8
+              access: ro
+              address: next
+              description: |
+                The maximum allowed value for prbs.ctl
+                sp_distort_mov_avg_num_taps_sel field.
           - block:
               name: sp_distort
               description: Interface to setpoints distortion levels regs

--- a/hdl/modules/fofb_sys_id/cheby/wb_fofb_sys_id_regs.h
+++ b/hdl/modules/fofb_sys_id/cheby/wb_fofb_sys_id_regs.h
@@ -31,6 +31,13 @@
 #define WB_FOFB_SYS_ID_REGS_PRBS_CTL_LFSR_LENGTH_SHIFT 11
 #define WB_FOFB_SYS_ID_REGS_PRBS_CTL_BPM_POS_DISTORT_EN 0x10000UL
 #define WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_EN 0x20000UL
+#define WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_MOV_AVG_NUM_TAPS_SEL_MASK 0x1c0000UL
+#define WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_MOV_AVG_NUM_TAPS_SEL_SHIFT 18
+
+/* The maximum allowed value for prbs.ctl
+sp_distort_mov_avg_num_taps_sel field.
+ */
+#define WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_MOV_AVG_MAX_NUM_TAPS_SEL_CTE 0x1004UL
 
 /* Interface to setpoints distortion levels regs */
 #define WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT 0x1040UL
@@ -98,8 +105,13 @@ struct wb_fofb_sys_id_regs {
  */
     uint32_t ctl;
 
-    /* padding to: 16 words */
-    uint32_t __padding_0[15];
+    /* [0x4]: REG (ro) The maximum allowed value for prbs.ctl
+sp_distort_mov_avg_num_taps_sel field.
+ */
+    uint8_t sp_distort_mov_avg_max_num_taps_sel_cte;
+
+    /* padding to: 64 words */
+    uint8_t __padding_0[59];
 
     /* [0x40]: BLOCK Interface to setpoints distortion levels regs */
     struct sp_distort {

--- a/hdl/modules/fofb_sys_id/fofb_sys_id_pkg.vhd
+++ b/hdl/modules/fofb_sys_id/fofb_sys_id_pkg.vhd
@@ -82,7 +82,8 @@ package fofb_sys_id_pkg is
   component prbs_sp_distort is
     generic (
       g_SP_WIDTH            : natural := 15;
-      g_DISTORT_LEVEL_WIDTH : natural := 16
+      g_DISTORT_LEVEL_WIDTH : natural := 16;
+      g_MAX_ORDER_SEL       : natural := 4
     );
     port (
       clk_i                 : in std_logic;
@@ -96,6 +97,7 @@ package fofb_sys_id_pkg is
       sp_valid_i            : in std_logic;
       distort_level_0_i     : in signed(g_DISTORT_LEVEL_WIDTH-1 downto 0);
       distort_level_1_i     : in signed(g_DISTORT_LEVEL_WIDTH-1 downto 0);
+      order_sel_i           : in natural range 0 to g_MAX_ORDER_SEL := 0;
       distort_sp_o          : out signed(g_SP_WIDTH-1 downto 0);
       distort_sp_valid_o    : out std_logic;
       prbs_o                : out std_logic;

--- a/hdl/modules/fofb_sys_id/prbs_sp_distort.vhd
+++ b/hdl/modules/fofb_sys_id/prbs_sp_distort.vhd
@@ -17,6 +17,7 @@
 -- Date         Version  Author              Description
 -- 2023-04-17   1.0      guilherme.ricioli   Created
 -- 2023-04-19   1.1      guilherme.ricioli   Wrap prbs_gen_for_sys_id
+-- 2023-05-13   1.2      guilherme.ricioli   Add distortion averaging
 --------------------------------------------------------------------------------
 
 library ieee;
@@ -33,7 +34,11 @@ entity prbs_sp_distort is
     g_SP_WIDTH            : natural := 15;
 
     -- Width of distortion levels
-    g_DISTORT_LEVEL_WIDTH : natural := 16
+    g_DISTORT_LEVEL_WIDTH : natural := 16;
+
+    -- Moving average maximum order
+    -- The maximum order being selected is given by '2**g_MAX_ORDER_SEL - 1'
+    g_MAX_ORDER_SEL       : natural := 4
   );
   port (
     -- Clock
@@ -61,6 +66,8 @@ entity prbs_sp_distort is
     prbs_lfsr_length_i    : in natural range 2 to 32 := 32;
 
     -- PRBS iteration signal
+    -- NOTE: The averaged distortion for the new PRBS value will be ready after
+    --       4 clock cycles.
     prbs_valid_i          : in std_logic;
 
     -- Setpoint
@@ -74,6 +81,10 @@ entity prbs_sp_distort is
 
     -- Distortion level for PRBS value '1'
     distort_level_1_i     : in signed(g_DISTORT_LEVEL_WIDTH-1 downto 0);
+
+    -- Moving average order selector
+    -- The order being selected is given by '2**order_sel_i - 1'
+    order_sel_i           : in natural range 0 to g_MAX_ORDER_SEL := 0;
 
     -- Distorted setpoint
     distort_sp_o          : out signed(g_SP_WIDTH-1 downto 0);
@@ -91,13 +102,46 @@ end entity prbs_sp_distort;
 
 architecture beh of prbs_sp_distort is
   signal prbs : std_logic := '0';
+  signal prbs_valid : std_logic := '0';
+  signal distort : signed(g_DISTORT_LEVEL_WIDTH-1 downto 0) := (others => '0');
+  signal distort_valid : std_logic := '0';
+  signal avgd_distort : signed(g_DISTORT_LEVEL_WIDTH-1 downto 0) := (others => '0');
+  signal avgd_distort_valid : std_logic := '0';
+  signal avgd_distort_reg : signed(g_DISTORT_LEVEL_WIDTH-1 downto 0) := (others => '0');
   signal sp_valid_d1 : std_logic := '0';
   -- 1-bit larger than the largest between sp_i and distort_level_{0,1}_i
   -- so to accomodate their sum
   signal distort_sp_aux : signed(maximum(g_SP_WIDTH, g_DISTORT_LEVEL_WIDTH) downto 0);
 begin
+  -- This process drives the PRBS distortion averaging.
+  -- After PRBS iteration, it selects the distortion level (based on PRBS
+  -- value), drives cmp_mov_avg_dyn with it and registers the averaged
+  -- distortion on avgd_distort_reg.
+  -- NOTE: The averaged distortion for a new PRBS value will be ready after 4
+  --       clock cycles:
+  --        1 cc for muxing the distortion levels;
+  --        2 cc for averaging the distortion; and
+  --        1 cc for registering it.
+  p_drive_distort_averaging : process(clk_i) is
+  begin
+    distort_valid <= '0';
+    if prbs_valid = '1' then
+      if prbs = '0' then
+        distort <= distort_level_0_i;
+      else  -- prbs_i = '1'
+        distort <= distort_level_1_i;
+      end if;
+      distort_valid <= '1';
+    elsif avgd_distort_valid = '1' then
+      avgd_distort_reg <= avgd_distort;
+    end if;
+  end process p_drive_distort_averaging;
 
-  process(clk_i) is
+  -- This process adds PRBS averaged distortion to the setpoint.
+  -- NOTE: There's no coordination between this process and
+  --       p_drive_distort_averaging. It simply uses the averaged distortion
+  --       registered on avgd_distort_reg.
+  p_add_avgd_distort : process(clk_i) is
     -- 1-bit larger than the largest between sp_i and distort_level_{0,1}_i
     -- This is done so there's no {over,under}flow on signed '+' operation
     variable v_resized_sp : signed(maximum(g_SP_WIDTH, g_DISTORT_LEVEL_WIDTH) downto 0);
@@ -109,14 +153,10 @@ begin
       else
         v_resized_sp := resize(sp_i, maximum(g_SP_WIDTH, g_DISTORT_LEVEL_WIDTH)+1);
 
-        -- Pipeline stage 1 of 2: sum or bypass PRBS distortion
+        -- Pipeline stage 1 of 2: sum or bypass PRBS averaged distortion
         -- #####################################################################
         if en_distort_i = '1' then
-          if prbs = '0' then
-            distort_sp_aux <= v_resized_sp + distort_level_0_i;
-          else  -- prbs_i = '1'
-            distort_sp_aux <= v_resized_sp + distort_level_1_i;
-          end if;
+          distort_sp_aux <= v_resized_sp + avgd_distort_reg;
         else  -- en_distort_i = '0'
           distort_sp_aux <= v_resized_sp;
         end if;
@@ -131,7 +171,7 @@ begin
         -- #####################################################################
       end if;
     end if;
-  end process;
+  end process p_add_avgd_distort;
 
   cmp_prbs_gen_for_sys_id : prbs_gen_for_sys_id
     port map (
@@ -143,9 +183,25 @@ begin
       valid_i         => prbs_valid_i,
       busy_o          => open,
       prbs_o          => prbs,
-      valid_o         => prbs_valid_o
+      valid_o         => prbs_valid
+    );
+
+  cmp_mov_avg_dyn : mov_avg_dyn
+    generic map (
+      g_MAX_ORDER_SEL => g_MAX_ORDER_SEL,
+      g_DATA_WIDTH    => g_DISTORT_LEVEL_WIDTH
+    )
+    port map (
+      clk_i           => clk_i,
+      rst_n_i         => rst_n_i,
+      order_sel_i     => order_sel_i,
+      data_i          => distort,
+      valid_i         => distort_valid,
+      avgd_data_o     => avgd_distort,
+      valid_o         => avgd_distort_valid
     );
 
   prbs_o <= prbs;
+  prbs_valid_o <= prbs_valid;
 
 end architecture beh;

--- a/hdl/sim/regs/wb_fofb_sys_id_regs_consts_pkg.vhd
+++ b/hdl/sim/regs/wb_fofb_sys_id_regs_consts_pkg.vhd
@@ -13,6 +13,8 @@ package wb_fofb_sys_id_regs_consts_pkg is
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_CTL_LFSR_LENGTH_OFFSET : Natural := 11;
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_CTL_BPM_POS_DISTORT_EN_OFFSET : Natural := 16;
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_EN_OFFSET : Natural := 17;
+  constant c_WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_MOV_AVG_NUM_TAPS_SEL_OFFSET : Natural := 18;
+  constant c_WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_MOV_AVG_MAX_NUM_TAPS_SEL_CTE_ADDR : Natural := 16#1004#;
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_ADDR : Natural := 16#1040#;
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_SIZE : Natural := 64;
   constant c_WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_CH_ADDR : Natural := 16#1040#;

--- a/hdl/testbench/prbs_sp_distort/prbs_sp_distort_tb.vhd
+++ b/hdl/testbench/prbs_sp_distort/prbs_sp_distort_tb.vhd
@@ -16,6 +16,8 @@
 -- 2023-04-17   1.0      guilherme.ricioli   Created
 --------------------------------------------------------------------------------
 
+-- TODO: Test moving average orders higher than 0.
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
@@ -75,6 +77,9 @@ begin
       f_wait_cycles(clk, 1);
       prbs_iterate <= '0';
       f_wait_clocked_signal(clk, prbs_valid, '1');
+      -- NOTE: Accounting for the distortion averaging (2 cc) and registering
+      --       (1 cc) delay
+      f_wait_cycles(clk, 3);
 
       -- Drive setpoint
       sp <= to_signed(sp_val, sp'length);
@@ -135,7 +140,8 @@ begin
   uut : prbs_sp_distort
     generic map (
       g_SP_WIDTH            => c_SP_WIDTH,
-      g_DISTORT_LEVEL_WIDTH => c_DISTORT_LEVEL_WIDTH
+      g_DISTORT_LEVEL_WIDTH => c_DISTORT_LEVEL_WIDTH,
+      g_MAX_ORDER_SEL       => 0
     )
     port map (
       clk_i                 => clk,
@@ -147,6 +153,7 @@ begin
       prbs_valid_i          => prbs_iterate,
       sp_i                  => sp,
       sp_valid_i            => sp_valid,
+      order_sel_i           => 0,
       distort_level_0_i     => c_DISTORT_LEVEL_0,
       distort_level_1_i     => c_DISTORT_LEVEL_1,
       distort_sp_o          => distort_sp,

--- a/hdl/testbench/xwb_fofb_sys_id/xwb_fofb_sys_id_tb.vhd
+++ b/hdl/testbench/xwb_fofb_sys_id/xwb_fofb_sys_id_tb.vhd
@@ -17,6 +17,12 @@
 -- 2023-05-03   1.1      guilherme.ricioli   Test PRBS distortion machinery
 --------------------------------------------------------------------------------
 
+-- TODO: Test
+--       c_WB_FOFB_SYS_ID_REGS_PRBS_CTL_SP_DISTORT_MOV_AVG_NUM_TAPS_SEL_OFFSET,
+--       c_WB_FOFB_SYS_ID_REGS_PRBS_SP_DISTORT_MOV_AVG_MAX_NUM_TAPS_SEL_CTE_ADDR
+--      and the setpoints distortion averaging itself. Currently, no averaging
+--      is done.
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
@@ -570,6 +576,9 @@ begin
       f_wait_cycles(clk, 1);
       prbs_iterate <= '0';
       f_wait_clocked_signal(clk, prbs_valid, '1');
+      -- NOTE: Accounting for the distortion averaging (2 cc) and registering
+      --       (1 cc) delay
+      f_wait_cycles(clk, 3);
 
       for ch in 0 to c_CHANNELS-1
       loop


### PR DESCRIPTION
In order to prevent our power supplies from saturating (hence introducing non-linear behaviors, undesirable for our sytem identification applications), moving average filters were added to the PRBS-based distortion signal. These filters allow us to smooth the power supply current setpoint transitions, which lowers the needed PI control effort, (hopefully) keeping it in the linear operation range.